### PR TITLE
Implement macos keyboard text entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ winapi = "0.2.8"
 user32-sys = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-graphics = "0.6.0"
+core-graphics = { git = "https://github.com/servo/core-graphics-rs", rev = "17535154051138dd5f52dcdf14f46a8b6537c95e" }
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ let mut enigo = Enigo::new();
 
 enigo.mouse_move_to(500, 200);
 enigo.mouse_click(1);
-//only on linux currently
+//only on linux and macos currently
 enigo.key_sequence("hello world");
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Cross platform input simulation in Rust!
 - [ ] Linux Wayland text
 - [ ] Linux Wayland keyboard DSL
 - [x] macOS mouse
-- [ ] macOS text
+- [x] macOS text
 - [ ] macOS keyboard DSL
 - [x] Win mouse
 - [ ] Win text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub trait KeyboardControllable {
     ///
     /// Emits keystrokes such that the given string is inputted.
     ///
-    /// This is currently only implemented on Linux. 
+    /// This is currently only implemented on Linux and macos. 
     ///
     /// # Example
     ///

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -213,6 +213,9 @@ impl MouseControllable for Enigo {
 
 impl KeyboardControllable for Enigo {
      fn key_sequence(&self, sequence: &str) {
-         unimplemented!()
+         let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).expect("Failed creating event source");
+         let event = CGEvent::new_keyboard_event(source, 0, true).expect("Failed creating event");
+         event.set_string(sequence);
+         event.post(CGEventTapLocation::HID);
      }
 }


### PR DESCRIPTION
Fixes #9.

The keyboard example works, but I have not done additional testing.

I had to update the core-graphics dependency for `set_string`, which is not available on crates.io.